### PR TITLE
[Feat] 공용 버튼 컴포넌트 구현(#19)

### DIFF
--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -1,0 +1,56 @@
+import { type HTMLAttributes } from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/app/_lib/cn';
+
+const buttonVariants = cva(
+  'flex h-[62px] items-center w-full justify-center gap-1 rounded-[14px] text-[16px] font-[500] hover:cursor-pointer ',
+  {
+    variants: {
+      theme: {
+        orange: 'text-white bg-orange-500 active:bg-orange-600',
+        gray: 'text-black bg-gray-200 active:bg-gray-300',
+      },
+      status: {
+        normal: 'hover:opacity-90',
+        disabled: 'cursor-not-allowed opacity-50',
+      },
+    },
+    defaultVariants: {
+      theme: 'orange',
+      status: 'normal',
+    },
+  }
+);
+
+interface ButtonProps
+  extends HTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  children: React.ReactNode;
+  type?: 'button' | 'submit' | 'reset';
+}
+
+const Button = ({
+  className,
+  theme,
+  status,
+  children,
+  onClick,
+  type = 'button',
+  ...props
+}: ButtonProps) => {
+  return (
+    <button
+      className={cn(buttonVariants({ theme, status, className }))}
+      type={type}
+      disabled={status === 'disabled'}
+      {...props}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export { Button, buttonVariants };

--- a/src/app/_components/layout/ScaledStage.tsx
+++ b/src/app/_components/layout/ScaledStage.tsx
@@ -1,5 +1,4 @@
-import clsx from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { cn } from '@/app/_lib/cn';
 
 import type { ScaledStageProps, StageVars } from '@/app/_components/layout/type';
 
@@ -40,7 +39,7 @@ const ScaledStage = ({
     <div className="min-h-screen w-full">
       <Backdrop backdrop={backdrop} />
       <div
-        className={clsx(
+        className={cn(
           'relative mx-auto flex min-h-dvh w-full max-w-[500px] flex-col overflow-hidden bg-white',
           showFrame && frameClassName
         )}
@@ -59,13 +58,11 @@ const ScaledStage = ({
         <div className="stage-scale-context" style={vars}>
           <div
             data-fixed-stage
-            className={twMerge(
-              clsx(
-                'relative h-full w-full bg-white shadow-xl',
-                allowScroll ? 'scroll-smooth-mobile overflow-auto' : 'overflow-hidden',
-                showFrame && frameClassName,
-                debugOutline && 'outline outline-1 outline-blue-300'
-              )
+            className={cn(
+              'relative h-full w-full bg-white shadow-xl',
+              allowScroll ? 'scroll-smooth-mobile overflow-auto' : 'overflow-hidden',
+              showFrame && frameClassName,
+              debugOutline && 'outline outline-1 outline-blue-300'
             )}
           >
             {children}

--- a/src/app/_components/layout/ScaledStage.tsx
+++ b/src/app/_components/layout/ScaledStage.tsx
@@ -37,10 +37,16 @@ const ScaledStage = ({
   };
 
   const productionStage = () => (
-    <div className="min-h-screen-safe w-full">
+    <div className="min-h-screen w-full">
       <Backdrop backdrop={backdrop} />
-      <div className={clsx('relative mx-auto w-full max-w-[500px]', showFrame && frameClassName)}>
-        {children}
+      <div
+        className={clsx(
+          'relative mx-auto flex min-h-dvh w-full max-w-[500px] flex-col overflow-hidden bg-white',
+          showFrame && frameClassName
+        )}
+      >
+        <main className="flex flex-1">{children}</main>
+
         {showLabel && <StageLabel text="max-w 500" />}
       </div>
     </div>

--- a/src/app/_components/ui/Button.tsx
+++ b/src/app/_components/ui/Button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/app/_lib/cn';
 
 const buttonVariants = cva(
-  'flex h-[62px] items-center w-full justify-center gap-1 rounded-[14px] text-[16px] font-[500] hover:cursor-pointer ',
+  'flex h-[62px] items-center w-full justify-center gap-1 rounded-[14px] text-[16px] font-[500] hover:cursor-pointer shrink-0 ',
   {
     variants: {
       theme: {

--- a/src/app/any/buttonTest/README.md
+++ b/src/app/any/buttonTest/README.md
@@ -1,0 +1,57 @@
+# Button Component
+
+버튼 UI 컴포넌트.  
+[class-variance-authority (cva)](https://cva.style/)를 사용하여 `theme`와 `status` 변형을 손쉽게 적용할 수 있습니다.
+
+---
+
+## Import
+
+```tsx
+import { Button } from '@/app/_components/ui/Button';
+```
+
+## Props
+
+| Prop        | Type                                  | Default    | Description             |
+| ----------- | ------------------------------------- | ---------- | ----------------------- |
+| `children`  | `React.ReactNode`                     | –          | 버튼 내부 콘텐츠        |
+| `theme`     | `"orange"` \| `"gray"`                | `"orange"` | 버튼 색상 테마          |
+| `status`    | `"normal"` \| `"disabled"`            | `"normal"` | 버튼 상태 (활성/비활성) |
+| `type`      | `"button"` \| `"submit"` \| `"reset"` | `"button"` | 버튼 type 속성          |
+| `onClick`   | `() => void`                          | –          | 클릭 이벤트 핸들러      |
+| `className` | `string`                              | –          | 추가 CSS 클래스         |
+| ...rest     | `HTMLAttributes<HTMLButtonElement>`   | –          | 기본 button 속성        |
+
+## Variants
+
+### Theme
+
+- **orange**: `text-white bg-orange-500 active:bg-orange-600`
+- **gray**: `text-black bg-gray-200 active:bg-gray-300`
+
+### Status
+
+- **normal**: `hover:opacity-90`
+- **disabled**: `cursor-not-allowed opacity-50`
+
+## Usage
+
+```tsx
+// 기본 사용
+<Button>기본 버튼</Button>
+
+// 모든 props 조합 가능
+<Button theme="gray" status="disabled" onClick={() => {}}>
+  버튼
+</Button>
+```
+
+```
+
+## Notes
+
+- `status="disabled"`를 주면 `disabled` 속성이 자동으로 적용됩니다.
+- `className`을 전달하면 variant 스타일과 병합됩니다.
+- 모든 HTML button 속성을 지원합니다.
+```

--- a/src/app/any/buttonTest/page.tsx
+++ b/src/app/any/buttonTest/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Button } from '@/app/_components/ui/Button';
+
+const ButtonTestPage = () => {
+  return (
+    <div className="flex w-full flex-col items-center justify-center gap-4 p-4">
+      {/* 기본 (theme: orange, status: normal) */}
+      <Button>기본 버튼</Button>
+
+      {/* 오렌지 + disabled */}
+      <Button status="disabled">비활성 버튼</Button>
+
+      {/* 회색 + normal */}
+      <Button theme="gray">취소</Button>
+
+      {/* 회색 + disabled */}
+      <Button theme="gray" status="disabled">
+        불가
+      </Button>
+
+      {/* submit 타입 버튼 */}
+      <Button type="submit">제출</Button>
+
+      {/* reset 타입 버튼 */}
+      <Button type="reset">초기화</Button>
+
+      {/* onClick 이벤트 */}
+      <Button onClick={() => alert('클릭됨!')}>클릭</Button>
+
+      {/* 커스텀 스타일 */}
+      <Button className="mt-4 w-3xs bg-blue-500 font-bold text-black shadow-lg">커스텀</Button>
+    </div>
+  );
+};
+
+export default ButtonTestPage;

--- a/src/app/any/page.tsx
+++ b/src/app/any/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 const AnyPage = () => {
   return (
     // 페이지 단일 스크롤: 화면 높이 폴백 유틸 사용
-    <main className="min-h-screen-safe bg-gradient-to-b from-white to-neutral-50 text-neutral-900">
+    <main className="bg-gradient-to-b from-white to-neutral-50 text-neutral-900">
       {/* Sticky 헤더: 주소창 변화(dvh) 상황에서도 안정 */}
       <header className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
         <div className="safe-padding mx-auto flex w-full max-w-[375px] items-center justify-between px-4 py-3 sm:max-w-[480px] md:max-w-[640px]">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

#19 

## 📋 작업 내용

버튼 컴포넌트 구현

## 🔧 변경 사항

- [x] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [x] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.
- src/app/_components/ui/Button.tsx - Button 컴포넌트 구현
- src/app/any/buttonTest/page.tsx - Button 컴포넌트 테스트 페이지
- src/app/any/buttonTest/readme.md - Button 컴포넌트 사용법 문서



## 📸 스크린샷

<img width="507" height="948" alt="스크린샷 2025-09-10 오전 2 43 21" src="https://github.com/user-attachments/assets/c4bac8c3-7518-4384-8f4d-999a7fc245f9" />

## 📄 기타

**구현된 기능**
- Theme: orange, gray
- Status: normal, disabled
- Type: button, submit, reset
- Props: onClick, className, 모든 HTML button 속성 지원